### PR TITLE
Changed the annotation reader logic for Info annotation

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/core/util/AnnotationsUtils.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/core/util/AnnotationsUtils.java
@@ -371,6 +371,7 @@ public abstract class AnnotationsUtils {
         if (info == null) {
             return Optional.empty();
         }
+
         boolean isEmpty = true;
         Info infoObject = new InfoImpl();
         if (StringUtils.isNotBlank(info.description())) {
@@ -389,11 +390,16 @@ public abstract class AnnotationsUtils {
             infoObject.setVersion(info.version());
             isEmpty = false;
         }
+
+        getContact(info.contact()).ifPresent(infoObject::setContact);
+        isEmpty &= infoObject.getContact() == null;
+
+        getLicense(info.license()).ifPresent(infoObject::setLicense);
+        isEmpty &= infoObject.getLicense() == null;
+
         if (isEmpty) {
             return Optional.empty();
         }
-        getContact(info.contact()).ifPresent(infoObject::setContact);
-        getLicense(info.license()).ifPresent(infoObject::setLicense);
 
         return Optional.of(infoObject);
     }

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/jaxrs2/Reader.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/jaxrs2/Reader.java
@@ -237,14 +237,15 @@ public class Reader {
         // OpenApiDefinition
         OpenAPIDefinition openAPIDefinition = ReflectionUtils.getAnnotation(cls, OpenAPIDefinition.class);
 
+        // If there are more than one openAPIDefinition annotation is present across the app, there is no
+        // guarantee which one is picked.
         if (openAPIDefinition != null) {
-
             // info
             AnnotationsUtils.getInfo(openAPIDefinition.info()).ifPresent(info -> openAPI.setInfo(info));
 
             // OpenApiDefinition security requirements
             SecurityParser.getSecurityRequirements(openAPIDefinition.security()).ifPresent(s -> openAPI.setSecurity(s));
-            //
+
             // OpenApiDefinition external docs
             AnnotationsUtils.getExternalDocumentation(openAPIDefinition.externalDocs()).ifPresent(docs -> openAPI.setExternalDocs(docs));
 
@@ -253,7 +254,6 @@ public class Reader {
 
             // OpenApiDefinition servers
             AnnotationsUtils.getServers(openAPIDefinition.servers()).ifPresent(servers -> openAPI.setServers(servers));
-
         }
 
         // class security schemes


### PR DESCRIPTION
Updated reader for the `Info` annotation to create an `Info` model object if any of the annotation fields are specified.

Signed-off-by: Navid Shakibapour <navid.shakibapour@gmail.com>