### PR TITLE
Issue #1820 - Fixed an issue with RequestBody on a method with no parameter

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/jaxrs2/Reader.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/jaxrs2/Reader.java
@@ -86,6 +86,7 @@ import com.ibm.ws.microprofile.openapi.impl.model.callbacks.CallbackImpl;
 import com.ibm.ws.microprofile.openapi.impl.model.media.ContentImpl;
 import com.ibm.ws.microprofile.openapi.impl.model.media.MediaTypeImpl;
 import com.ibm.ws.microprofile.openapi.impl.model.media.SchemaImpl;
+import com.ibm.ws.microprofile.openapi.impl.model.parameters.ParameterImpl;
 import com.ibm.ws.microprofile.openapi.impl.model.parameters.RequestBodyImpl;
 import com.ibm.ws.microprofile.openapi.impl.model.responses.APIResponseImpl;
 import com.ibm.ws.microprofile.openapi.impl.model.responses.APIResponsesImpl;
@@ -372,7 +373,7 @@ public class Reader {
                         continue;
                     }
                     setPathItemOperation(pathItemObject, httpMethod, operation);
-
+                    org.eclipse.microprofile.openapi.annotations.parameters.RequestBody methodRequestBody = method.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.RequestBody.class);
                     List<Parameter> operationParameters = new ArrayList<>();
                     Annotation[][] paramAnnotations = ReflectionUtils.getParameterAnnotations(method);
                     if (annotatedMethod == null) { // annotatedMethod not null only when method with 0-2 parameters
@@ -389,9 +390,8 @@ public class Reader {
                                                    operation,
                                                    methodConsumes,
                                                    classConsumes,
-                                                   operationParameters,
                                                    paramAnnotations[i],
-                                                   type, method.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.RequestBody.class));
+                                                   methodRequestBody);
                             }
                         }
                     } else {
@@ -408,11 +408,19 @@ public class Reader {
                                                    operation,
                                                    methodConsumes,
                                                    classConsumes,
-                                                   operationParameters,
                                                    paramAnnotations[i],
-                                                   type, method.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.RequestBody.class));
+                                                   methodRequestBody);
                             }
                         }
+                    }
+
+                    if (operation.getRequestBody() == null) {
+                        processRequestBody(new ParameterImpl(),
+                                           operation,
+                                           methodConsumes,
+                                           classConsumes,
+                                           null,
+                                           methodRequestBody);
                     }
 
                     if (operationParameters.size() > 0) {
@@ -633,17 +641,19 @@ public class Reader {
         return content;
     }
 
-    protected void processRequestBody(Parameter requestBodyParameter, Operation operation,
-                                      Consumes methodConsumes, Consumes classConsumes,
-                                      List<Parameter> operationParameters,
-                                      Annotation[] paramAnnotations, Type type, org.eclipse.microprofile.openapi.annotations.parameters.RequestBody methododRequestBody) {
+    protected void processRequestBody(Parameter requestBodyParameter,
+                                      Operation operation,
+                                      Consumes methodConsumes,
+                                      Consumes classConsumes,
+                                      Annotation[] paramAnnotations,
+                                      org.eclipse.microprofile.openapi.annotations.parameters.RequestBody methodRequestBody) {
         if (operation.getRequestBody() == null) {
-            org.eclipse.microprofile.openapi.annotations.parameters.RequestBody requestBodyAnnotation = getRequestBody(Arrays.asList(paramAnnotations));
-
-            if (requestBodyAnnotation == null) {
-                if (methododRequestBody != null) {
-                    requestBodyAnnotation = methododRequestBody;
-                }
+            org.eclipse.microprofile.openapi.annotations.parameters.RequestBody requestBodyAnnotation = null;
+            if (paramAnnotations != null) {
+                requestBodyAnnotation = getRequestBody(Arrays.asList(paramAnnotations));
+            }
+            if (requestBodyAnnotation == null && methodRequestBody != null) {
+                requestBodyAnnotation = methodRequestBody;
             }
 
             if (requestBodyAnnotation != null) {
@@ -855,7 +865,7 @@ public class Reader {
         }
 
         // class tags after tags defined as field of @Operation
-        else if (classTags != null) {
+        else if (classTags != null && !classTags.isEmpty()) {
             operation.setTags(new ArrayList<>(classTags));
         }
 

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/model/media/SchemaImpl.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/model/media/SchemaImpl.java
@@ -76,6 +76,10 @@ public class SchemaImpl implements Schema {
     public SchemaImpl() {}
 
     public SchemaImpl(SchemaImpl schema) {
+        if (schema == null) {
+            return;
+        }
+
         this._default = schema.getDefaultValue();
         this.name = schema.getName();
         this.title = schema.getTitle();


### PR DESCRIPTION
PR for issue issue #1820:
- Fix for when a `@RequestBody` annotation is added to a method without any other paramete. Now it is scanned.
- Minor fix in `SchemaImpl` constructor.
- Minor fix in `@Tag` handling logic for not adding empty `Tag`