### PR TITLE
Issue #2023 - Improved FAT tests

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi_fat/.classpath
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/.classpath
@@ -3,9 +3,9 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/appWithAnnotations/src"/>
 	<classpathentry kind="src" path="test-applications/appWithStaticDoc/src"/>
-	<classpathentry kind="src" path="test-applications/simpleServlet"/>
 	<classpathentry kind="src" path="test-applications/pure-jaxrs/src"/>
 	<classpathentry kind="src" path="test-applications/complete-flow/src"/>
+	<classpathentry kind="src" path="test-applications/simpleServlet/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorTest.java
@@ -76,6 +76,10 @@ public class ApplicationProcessorTest extends FATServletClient {
         ShrinkHelper.defaultApp(server, APP_NAME_11, "app.web.complete.flow.*");
 
         LibertyServer.setValidateApps(false);
+
+        // Change server ports to the default ones
+        OpenAPITestUtil.changeServerPorts(server, server.getHttpDefaultPort(), server.getHttpDefaultSecurePort());
+
         server.startServer(c.getSimpleName() + ".log");
     }
 
@@ -126,7 +130,7 @@ public class ApplicationProcessorTest extends FATServletClient {
         OpenAPITestUtil.waitForApplicationProcessorAddedEvent(server, APP_NAME_2);
         String app2Doc = OpenAPIConnection.openAPIDocsConnection(server, false).download();
         openapiNode = OpenAPITestUtil.readYamlTree(app2Doc);
-        OpenAPITestUtil.checkServer(openapiNode, "https:///MySimpleAPI/1.0.0");
+        OpenAPITestUtil.checkServer(openapiNode, OpenAPITestUtil.getServerURLs(server, server.getHttpDefaultPort(), server.getHttpDefaultSecurePort(), APP_NAME_2));
         OpenAPITestUtil.checkPaths(openapiNode, 1);
 
         // Remove the appWithStaticDoc app and ensure that the default empty OpenAPI documentation is created

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ProxySupportTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ProxySupportTest.java
@@ -42,9 +42,9 @@ public class ProxySupportTest extends FATServletClient {
     private static final Class<?> c = ProxySupportTest.class;
     private static final String REFERER = "Referer";
 
-    private static final String APP_NAME_1 = "pure-jaxrs";
+    private static final String APP_NAME_1 = "appWithStaticDoc";
 
-    @Server("ApplicationProcessorServer")
+    @Server("ProxySupportServer")
     public static LibertyServer server;
 
     @Rule
@@ -54,7 +54,7 @@ public class ProxySupportTest extends FATServletClient {
     public static void setUpTest() throws Exception {
         HttpUtils.trustAllCertificates();
 
-        ShrinkHelper.defaultApp(server, APP_NAME_1, "app.web.pure.jaxrs");
+        ShrinkHelper.defaultApp(server, APP_NAME_1);
 
         LibertyServer.setValidateApps(false);
         server.startServer(c.getSimpleName() + ".log");
@@ -76,7 +76,7 @@ public class ProxySupportTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWWKO1650E");
+        server.stopServer();
     }
 
     /**

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/utils/OpenAPITestUtil.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/utils/OpenAPITestUtil.java
@@ -252,13 +252,17 @@ public class OpenAPITestUtil {
         http.setHttpPort(httpPort);
         http.setHttpsPort(httpsPort);
 
-        // Set the mark to the current end of log
-        server.setMarkToEndOfLog();
+        if (server.isStarted()) {
+            // Set the mark to the current end of log
+            server.setMarkToEndOfLog();
 
-        // Save the config and wait for message that was a result of the config change
-        server.updateServerConfiguration(config);
-        assertNotNull("FAIL: Didn't get expected config update log messages.", server.waitForConfigUpdateInLogUsingMark(null, false));
-        server.resetLogMarks();
+            // Save the config and wait for message that was a result of the config change
+            server.updateServerConfiguration(config);
+            assertNotNull("FAIL: Didn't get expected config update log messages.", server.waitForConfigUpdateInLogUsingMark(null, false));
+            server.resetLogMarks();
+        } else {
+            server.updateServerConfiguration(config);
+        }
     }
 
     public static String[] getServerURLs(LibertyServer server, int httpPort, int httpsPort) {

--- a/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/ProxySupportServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/ProxySupportServer/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info=enabled:test=all=enabled:logservice=all=enabled:mpOpenAPI=debug=enabled

--- a/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/ProxySupportServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/ProxySupportServer/server.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+  <!-- Note that fatTestPorts.xml is not included because we control creation of all ports in fats -->
+  <include location="../fatTestCommon.xml" />
+
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>ssl-1.0</feature>
+    <feature>mpOpenAPI-1.0</feature>
+  </featureManager>
+
+  <keyStore id="defaultKeyStore" password="password" />
+
+</server>

--- a/dev/com.ibm.ws.microprofile.openapi_fat/test-applications/appWithStaticDoc/resources/META-INF/openapi.yaml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/test-applications/appWithStaticDoc/resources/META-INF/openapi.yaml
@@ -1,7 +1,4 @@
 openapi: 3.0.0
-servers:
-  - description: MySimpleAPI
-    url: https:///MySimpleAPI/1.0.0
 info:
   description: This is a simple API
   version: "1.0.0"


### PR DESCRIPTION
PR for issue #2023:
- Changed Application Processor test to change server port before starting a server to avoid conflicting port issue
- Created a separate server for the Proxy Support tests
- Removed validation error code from stopServer